### PR TITLE
Add multi-tenancy

### DIFF
--- a/app/auth/components/LoginForm.tsx
+++ b/app/auth/components/LoginForm.tsx
@@ -30,7 +30,6 @@ export const LoginForm = (props: LoginFormProps) => {
           schema={Login}
           initialValues={{ email: "", password: "" }}
           onSubmit={async (values) => {
-            console.log(values)
             try {
               await loginMutation(values)
               props.onSuccess?.()

--- a/app/auth/components/SignupForm.tsx
+++ b/app/auth/components/SignupForm.tsx
@@ -18,7 +18,7 @@ export const SignupForm = (props: SignupFormProps) => {
       <Form
         submitText="Create Account"
         schema={Signup}
-        initialValues={{ email: "", password: "" }}
+        initialValues={{ email: "", handle: "", password: "" }}
         onSubmit={async (values) => {
           try {
             await signupMutation(values)
@@ -34,6 +34,7 @@ export const SignupForm = (props: SignupFormProps) => {
         }}
       >
         <LabeledTextField name="email" label="Email" placeholder="Email" />
+        <LabeledTextField name="handle" label="Handle" placeholder="@handle" />
         <LabeledTextField name="password" label="Password" placeholder="Password" type="password" />
       </Form>
     </div>

--- a/app/auth/mutations/forgotPassword.test.ts
+++ b/app/auth/mutations/forgotPassword.test.ts
@@ -22,6 +22,7 @@ describe("forgotPassword mutation", () => {
     const user = await db.user.create({
       data: {
         email: "user@example.com",
+        role: "CUSTOMER",
         tokens: {
           // Create old token to ensure it's deleted
           create: {

--- a/app/auth/mutations/login.ts
+++ b/app/auth/mutations/login.ts
@@ -1,7 +1,6 @@
 import { resolver, SecurePassword, AuthenticationError } from "blitz"
 import db from "db"
 import { Login } from "../validations"
-import { Role } from "types"
 
 export const authenticateUser = async (rawEmail: string, rawPassword: string) => {
   const email = rawEmail.toLowerCase().trim()
@@ -22,8 +21,13 @@ export const authenticateUser = async (rawEmail: string, rawPassword: string) =>
 }
 
 export default resolver.pipe(resolver.zod(Login), async ({ email, password }, ctx) => {
-  // This throws an error if credentials are invalid
-  const user = await authenticateUser(email, password)
+  // const user = await authenticateUser(email, password)
+  await authenticateUser(email, password)
+
+  const user = await db.user.findFirst({
+    where: { email },
+    select: { id: true, name: true, email: true, role: true, memberships: true },
+  })
 
   await ctx.session.$create({
     userId: user.id,

--- a/app/auth/mutations/login.ts
+++ b/app/auth/mutations/login.ts
@@ -25,7 +25,11 @@ export default resolver.pipe(resolver.zod(Login), async ({ email, password }, ct
   // This throws an error if credentials are invalid
   const user = await authenticateUser(email, password)
 
-  await ctx.session.$create({ userId: user.id, role: user.role as Role })
+  await ctx.session.$create({
+    userId: user.id,
+    roles: [user.role, user.memberships[0].role],
+    workspaceId: user.memberships[0].workspaceId,
+  })
 
   return user
 })

--- a/app/auth/mutations/login.ts
+++ b/app/auth/mutations/login.ts
@@ -5,13 +5,22 @@ import { Login } from "../validations"
 export const authenticateUser = async (rawEmail: string, rawPassword: string) => {
   const email = rawEmail.toLowerCase().trim()
   const password = rawPassword.trim()
-  const user = await db.user.findFirst({ where: { email } })
+  const user = await db.user.findFirst({
+    where: { email },
+    select: {
+      id: true,
+      hashedPassword: true,
+      name: true,
+      email: true,
+      role: true,
+      memberships: true,
+    },
+  })
   if (!user) throw new AuthenticationError()
 
   const result = await SecurePassword.verify(user.hashedPassword, password)
 
   if (result === SecurePassword.VALID_NEEDS_REHASH) {
-    // Upgrade hashed password with a more secure hash
     const improvedHash = await SecurePassword.hash(password)
     await db.user.update({ where: { id: user.id }, data: { hashedPassword: improvedHash } })
   }
@@ -21,18 +30,12 @@ export const authenticateUser = async (rawEmail: string, rawPassword: string) =>
 }
 
 export default resolver.pipe(resolver.zod(Login), async ({ email, password }, ctx) => {
-  // const user = await authenticateUser(email, password)
-  await authenticateUser(email, password)
-
-  const user = await db.user.findFirst({
-    where: { email },
-    select: { id: true, name: true, email: true, role: true, memberships: true },
-  })
+  const user = await authenticateUser(email, password)
 
   await ctx.session.$create({
     userId: user.id,
-    roles: [user.role, user.memberships[0].role],
-    workspaceId: user.memberships[0].workspaceId,
+    roles: [user.role, user.memberships[0]!.role],
+    workspaceId: user.memberships[0]!.workspaceId,
   })
 
   return user

--- a/app/auth/mutations/resetPassword.test.ts
+++ b/app/auth/mutations/resetPassword.test.ts
@@ -27,6 +27,19 @@ describe("resetPassword mutation", () => {
     const user = await db.user.create({
       data: {
         email: "user@example.com",
+        role: "CUSTOMER",
+        memberships: {
+          create: [
+            {
+              role: "OWNER",
+              workspace: {
+                create: {
+                  handle: "testing",
+                },
+              },
+            },
+          ],
+        },
         tokens: {
           // Create old token to ensure it's deleted
           create: [

--- a/app/auth/mutations/signup.ts
+++ b/app/auth/mutations/signup.ts
@@ -24,7 +24,7 @@ export default resolver.pipe(resolver.zod(Signup), async ({ email, password, han
         },
       },
     },
-    select: { id: true, name: true, email: true, role: true },
+    select: { id: true, name: true, email: true, role: true, memberships: true },
   })
 
   const emailCode = await verifyEmail.generateCode(hashedPassword)
@@ -33,7 +33,11 @@ export default resolver.pipe(resolver.zod(Signup), async ({ email, password, han
     sendEmailWithTemplate(email, "welcome", {
       verify_email_url: url`/verifyEmail/${emailCode}`,
     }),
-    ctx.session.$create({ userId: user.id, role: user.role as Role }),
+    ctx.session.$create({
+      userId: user.id,
+      roles: [user.role, user.memberships[0].role],
+      workspaceId: user.memberships[0].workspaceId,
+    }),
   ])
 
   return user

--- a/app/auth/mutations/signup.ts
+++ b/app/auth/mutations/signup.ts
@@ -35,8 +35,8 @@ export default resolver.pipe(resolver.zod(Signup), async ({ email, password, han
     }),
     ctx.session.$create({
       userId: user.id,
-      roles: [user.role, user.memberships[0].role],
-      workspaceId: user.memberships[0].workspaceId,
+      roles: [user.role, user.memberships[0]!.role],
+      workspaceId: user.memberships[0]!.workspaceId,
     }),
   ])
 

--- a/app/auth/mutations/signup.ts
+++ b/app/auth/mutations/signup.ts
@@ -6,10 +6,24 @@ import { sendEmailWithTemplate } from "app/postmark"
 import { url } from "app/url"
 import * as verifyEmail from "../verify-email"
 
-export default resolver.pipe(resolver.zod(Signup), async ({ email, password }, ctx) => {
+export default resolver.pipe(resolver.zod(Signup), async ({ email, password, handle }, ctx) => {
   const hashedPassword = await SecurePassword.hash(password.trim())
   const user = await db.user.create({
-    data: { email: email.toLowerCase().trim(), hashedPassword, role: "USER" },
+    data: {
+      email: email.toLowerCase().trim(),
+      hashedPassword,
+      role: "CUSTOMER",
+      memberships: {
+        create: {
+          role: "OWNER",
+          workspace: {
+            create: {
+              handle,
+            },
+          },
+        },
+      },
+    },
     select: { id: true, name: true, email: true, role: true },
   })
 

--- a/app/auth/validations.ts
+++ b/app/auth/validations.ts
@@ -4,6 +4,7 @@ const password = z.string().min(10).max(100)
 
 export const Signup = z.object({
   email: z.string().email(),
+  handle: z.string().min(3),
   password,
 })
 

--- a/app/core/components/navbar.tsx
+++ b/app/core/components/navbar.tsx
@@ -20,7 +20,7 @@ import { Link, Routes, useMutation, useRouter } from "blitz"
 import { Suspense } from "react"
 import { useCurrentUser } from "../hooks/useCurrentUser"
 import logout from "../../auth/mutations/logout"
-import { Router } from "next/router"
+import { useCurrentWorkspace } from "../hooks/useCurrentWorkspace"
 
 const features = [
   {
@@ -366,10 +366,12 @@ export default function Example() {
 
 const UserInfo = () => {
   const currentUser = useCurrentUser()
+  const currentWorkspace = useCurrentWorkspace()
   const [logoutMutation] = useMutation(logout)
   const router = useRouter()
+  console.log(currentWorkspace)
 
-  if (currentUser) {
+  if (currentUser && currentWorkspace) {
     return (
       <>
         <button
@@ -385,7 +387,7 @@ const UserInfo = () => {
           {/* User id: <code>{currentUser.id}</code>
           <br />
           User role: <code>{currentUser.role}</code> */}
-          <a>Go to dashboard</a>
+          <a>Go to @{currentWorkspace.handle}</a>
         </Link>
       </>
     )

--- a/app/core/hooks/useCurrentWorkspace.ts
+++ b/app/core/hooks/useCurrentWorkspace.ts
@@ -1,0 +1,7 @@
+import { useQuery } from "blitz"
+import getCurrentWorkspace from "../../workspaces/queries/getCurrentWorkspace"
+
+export const useCurrentWorkspace = () => {
+  const [workspace] = useQuery(getCurrentWorkspace, null)
+  return workspace
+}

--- a/app/pages/index.test.tsx
+++ b/app/pages/index.test.tsx
@@ -12,12 +12,12 @@ test.skip("renders blitz documentation link", () => {
   // when you remove the the default content from the page
 
   // This is an example on how to mock api hooks when testing
-  mockUseCurrentUser.mockReturnValue({
-    id: 1,
-    name: "User",
-    email: "user@email.com",
-    role: "user",
-  })
+  // mockUseCurrentUser.mockReturnValue({
+  //   id: 1,
+  //   name: "User",
+  //   email: "user@email.com",
+  //   role: "CUSTOMER",
+  // })
 
   const { getByText } = render(<Home />)
   const linkElement = getByText(/Documentation/i)

--- a/app/users/queries/getCurrentUser.ts
+++ b/app/users/queries/getCurrentUser.ts
@@ -6,7 +6,7 @@ export default async function getCurrentUser(_ = null, { session }: Ctx) {
 
   const user = await db.user.findFirst({
     where: { id: session.userId },
-    select: { id: true, name: true, email: true, role: true },
+    select: { id: true, name: true, email: true, role: true, memberships: true },
   })
 
   return user

--- a/app/workspaces/queries/getCurrentWorkspace.ts
+++ b/app/workspaces/queries/getCurrentWorkspace.ts
@@ -1,0 +1,12 @@
+import { Ctx } from "blitz"
+import db from "db"
+
+export default async function getCurrentWorkspace(_ = null, { session }: Ctx) {
+  if (!session.workspaceId) return null
+
+  const user = await db.workspace.findFirst({
+    where: { id: session.workspaceId },
+  })
+
+  return user
+}

--- a/db/migrations/20210823094806_add_email_verification/migration.sql
+++ b/db/migrations/20210823094806_add_email_verification/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "User" ADD COLUMN     "emailIsVerified" BOOLEAN NOT NULL DEFAULT false;

--- a/db/migrations/20210913120605_init/migration.sql
+++ b/db/migrations/20210913120605_init/migration.sql
@@ -1,5 +1,31 @@
 -- CreateEnum
+CREATE TYPE "MembershipRole" AS ENUM ('OWNER', 'ADMIN', 'USER');
+
+-- CreateEnum
+CREATE TYPE "GlobalRole" AS ENUM ('SUPERADMIN', 'CUSTOMER');
+
+-- CreateEnum
 CREATE TYPE "TokenType" AS ENUM ('RESET_PASSWORD');
+
+-- CreateTable
+CREATE TABLE "Workspace" (
+    "id" SERIAL NOT NULL,
+    "handle" TEXT NOT NULL,
+
+    PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Membership" (
+    "id" SERIAL NOT NULL,
+    "role" "MembershipRole" NOT NULL,
+    "workspaceId" INTEGER NOT NULL,
+    "userId" INTEGER,
+    "invitedName" TEXT,
+    "invitedEmail" TEXT,
+
+    PRIMARY KEY ("id")
+);
 
 -- CreateTable
 CREATE TABLE "User" (
@@ -8,8 +34,9 @@ CREATE TABLE "User" (
     "updatedAt" TIMESTAMP(3) NOT NULL,
     "name" TEXT,
     "email" TEXT NOT NULL,
+    "emailIsVerified" BOOLEAN NOT NULL DEFAULT false,
     "hashedPassword" TEXT,
-    "role" TEXT NOT NULL DEFAULT E'USER',
+    "role" "GlobalRole" NOT NULL,
 
     PRIMARY KEY ("id")
 );
@@ -45,6 +72,9 @@ CREATE TABLE "Token" (
 );
 
 -- CreateIndex
+CREATE UNIQUE INDEX "Membership.workspaceId_invitedEmail_unique" ON "Membership"("workspaceId", "invitedEmail");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "User.email_unique" ON "User"("email");
 
 -- CreateIndex
@@ -52,6 +82,12 @@ CREATE UNIQUE INDEX "Session.handle_unique" ON "Session"("handle");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Token.hashedToken_type_unique" ON "Token"("hashedToken", "type");
+
+-- AddForeignKey
+ALTER TABLE "Membership" ADD FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Membership" ADD FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "Session" ADD FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/db/migrations/20210913130045_unique_handles/migration.sql
+++ b/db/migrations/20210913130045_unique_handles/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[handle]` on the table `Workspace` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Workspace.handle_unique" ON "Workspace"("handle");

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -14,7 +14,7 @@ generator client {
 
 model Workspace {
   id     Int    @id @default(autoincrement())
-  handle String
+  handle String @unique
 
   membership Membership[]
 }

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -13,8 +13,8 @@ generator client {
 // --------------------------------------
 
 model Workspace {
-  id   Int    @id @default(autoincrement())
-  name String
+  id     Int    @id @default(autoincrement())
+  handle String
 
   membership Membership[]
 }

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -12,18 +12,53 @@ generator client {
 
 // --------------------------------------
 
-model User {
-  id              Int      @id @default(autoincrement())
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
-  name            String?
-  email           String   @unique
-  emailIsVerified Boolean  @default(false)
-  hashedPassword  String?
-  role            String   @default("USER")
+model Workspace {
+  id   Int    @id @default(autoincrement())
+  name String
 
-  tokens   Token[]
-  sessions Session[]
+  membership Membership[]
+}
+
+model Membership {
+  id   Int            @id @default(autoincrement())
+  role MembershipRole
+
+  workspace   Workspace @relation(fields: [workspaceId], references: [id])
+  workspaceId Int
+
+  user   User? @relation(fields: [userId], references: [id])
+  userId Int?
+
+  invitedName  String?
+  invitedEmail String?
+
+  @@unique([workspaceId, invitedEmail])
+}
+
+enum MembershipRole {
+  OWNER
+  ADMIN
+  USER
+}
+
+enum GlobalRole {
+  SUPERADMIN
+  CUSTOMER
+}
+
+model User {
+  id              Int        @id @default(autoincrement())
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+  name            String?
+  email           String     @unique
+  emailIsVerified Boolean    @default(false)
+  hashedPassword  String?
+  role            GlobalRole
+
+  tokens      Token[]
+  sessions    Session[]
+  memberships Membership[]
 }
 
 model Session {

--- a/types.ts
+++ b/types.ts
@@ -1,8 +1,7 @@
 import { DefaultCtx, SessionContext, SimpleRolesIsAuthorized } from "blitz"
-import { User } from "db"
+import { GlobalRole, MembershipRole, Workspace, User } from "db"
 
-// Note: You should switch to Postgres and then use a DB enum for role type
-export type Role = "ADMIN" | "USER"
+export type Role = MembershipRole | GlobalRole
 
 declare module "blitz" {
   export interface Ctx extends DefaultCtx {
@@ -12,7 +11,8 @@ declare module "blitz" {
     isAuthorized: SimpleRolesIsAuthorized<Role>
     PublicData: {
       userId: User["id"]
-      role: Role
+      roles: Array<Role>
+      workspaceId?: Workspace["id"]
     }
   }
 }


### PR DESCRIPTION
This PR adds multi-tenancy. 

- [x] Implement multi-tenancy schema
- [x] Implement sign up procedure
- [x] Implement login procedure
- [x] Display current workspace

# Multi-tenancy specifications

See the [BlitzJS documentation](https://blitzjs.com/docs/multitenancy) and the [Bullet Train Blog post about multi-tenancy](https://blog.bullettrain.co/teams-should-be-an-mvp-feature/).

These specifications are subject to further changes as implementation progresses.

## Definitions

* "Workspace" is interchangeable with "Organization"
* "Researcher" is interchangeable with "User"

## Current work

### First level workspaces (individual researchers; N=1)

This is the first level of implementation required for the February 2022 launch. This ensures the extensibility for practical multi-tenancy but in essence runs a regular account system still.

* Each researcher gets a workspace for themselves upon account creation.
* Each workspace gets a unique `@handle`
* A researcher's app session may only be active for one of the workspaces a researcher is a member of
* Each workspace has the following roles:
	* Owner
	* Admin
	* User
* Modules are linked to the current workspace
* Other workspaces can be invited to co-author a module

## Future work

### Nth level workspace (N > 1)
* A researcher can create additional workspaces (e.g., for a lab, N=2)
* A researcher can invite other workspaces to their current workspace
	* Example: @A invites @B to be a part of their newly created @LAB1 (N=2).
	* Example: @LAB1 invites @LAB2 to join @CONSORTIUM (N=3)
	* Nth level workspace invites are for a specific role
		* Individuals users receive the maximum privileges based on their role in the invited workspace (no permission expansion)
		* Example: @LAB1 is invited to @CONSORTIUM in an admin role -> the admins of @LAB1 will receive admin status in @CONSORTIUM. Authors in @LAB1 will receive author status in @CONSORTIUM.
* A researcher can accept invitations to other's workspaces (through email? In app?)

![Screenshot 2021-09-13 at 16 32 58](https://user-images.githubusercontent.com/2946344/133102865-3ac41dfc-827a-4c87-9648-3db39d3d7bbc.png)
