### PR TITLE
Add DOI suffix generator

### DIFF
--- a/app/modules/mutations/generateSuffix.ts
+++ b/app/modules/mutations/generateSuffix.ts
@@ -37,7 +37,7 @@ const getRandomInt = (min, max) => {
   return Math.floor(Math.random() * (max - min)) + min
 }
 
-const generateSuffix = () => {
+const generateSuffix = async () => {
   let generatorValue = getRandomInt(17179869184, 34359738367)
   let generatorOutput = ""
 

--- a/app/pages/modules/mutations/generateSuffix.tsx
+++ b/app/pages/modules/mutations/generateSuffix.tsx
@@ -1,0 +1,58 @@
+let ENCODE_CHARS = [
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  "a",
+  "b",
+  "c",
+  "d",
+  "e",
+  "f",
+  "g",
+  "h",
+  "j",
+  "k",
+  "m",
+  "n",
+  "p",
+  "q",
+  "r",
+  "s",
+  "t",
+  "v",
+  "w",
+  "x",
+  "y",
+  "z",
+]
+
+const getRandomInt = (min, max) => {
+  return Math.floor(Math.random() * (max - min)) + min
+}
+
+const generateSuffix = () => {
+  let generatorValue = getRandomInt(17179869184, 34359738367)
+  let generatorOutput = ""
+
+  generatorValue
+    .toString(2)
+    .match(/.{1,5}/g)
+    .map((item) => {
+      if (generatorOutput.length > 0 && generatorOutput.length % 4 == 0) {
+        generatorOutput += "-"
+      }
+      generatorOutput += ENCODE_CHARS[parseInt(item, 2)]
+    })
+  generatorOutput += ENCODE_CHARS[generatorValue % 32]
+
+  return generatorOutput
+}
+
+export default generateSuffix


### PR DESCRIPTION
This adds a DOI suffix generator (no implementation beyond that!). The specifications for this generator are outlined in this upcoming [blog post](https://blog.libscie.org/p/f825040f-8930-4e50-9b6f-b6206d5356f8/) (sneak peek for the GitHub watchers 😉 ).

Examples of the suffixes generated:

```
wb8r-sxqq
m2f7-2bdd
vmd7-7dyy
rrbj-kj55
ghjx-k6zz
jbfx-pjqq
sehf-ysrr
rwr8-2djj
s76q-pghh
w8ea-pbtt
m3d9-3aff
zy8w-74ff
```