### PR TITLE
Update modulo

### DIFF
--- a/app/modules/mutations/generateSuffix.ts
+++ b/app/modules/mutations/generateSuffix.ts
@@ -37,7 +37,7 @@ const getRandomInt = (min, max) => {
   return Math.floor(Math.random() * (max - min)) + min
 }
 
-const generateSuffix = async () => {
+const generateSuffix = () => {
   let generatorValue = getRandomInt(17179869184, 34359738367)
   let generatorOutput = ""
 
@@ -50,7 +50,7 @@ const generateSuffix = async () => {
       }
       generatorOutput += ENCODE_CHARS[parseInt(item, 2)]
     })
-  generatorOutput += ENCODE_CHARS[generatorValue % 32]
+  generatorOutput += ENCODE_CHARS[generatorValue % 31]
 
   return generatorOutput
 }


### PR DESCRIPTION
This PR fixes the DOI suffix generator to provide better results. Please see #16 for initial implementation and [this sneak peek blog](https://blog.libscie.org/p/f825040f-8930-4e50-9b6f-b6206d5356f8/) about the DOI suffix strategy.

## Old

The suffix always ended with the same two characters

```
hank-nt55
vw6s-y9ee
p86a-s5hh
pp0a-2111
z77k-xypp
h4ad-zr77
mqqr-qsdd
zafq-xeqq
v7x7-eq22
```

## New

The suffix ends with different characters most of the time

```
r2kf-bbh6
va68-mzq1
pab1-bxpd
mp7m-x88n
wmn5-rpvq
y7ty-xfr6
kre6-bwmx
qtwt-qmsg
zr96-r94e
xttw-dgze
```