### PR TITLE
Add email verification banner (and resend)

### DIFF
--- a/app/auth/mutations/resendVerification.ts
+++ b/app/auth/mutations/resendVerification.ts
@@ -1,0 +1,25 @@
+import { resolver } from "blitz"
+import db from "db"
+import { sendEmailWithTemplate } from "app/postmark"
+import { url } from "app/url"
+import * as verifyEmail from "../verify-email"
+
+export default resolver.pipe(async (_, ctx) => {
+  const user = await db.user.findFirst({
+    where: {
+      id: ctx.session.$publicData.userId!,
+    },
+  })
+
+  const emailCode = await verifyEmail.generateCode(user!.hashedPassword!)
+
+  await Promise.all([
+    sendEmailWithTemplate(user!.email!, "welcome", {
+      handle: user!.email!,
+      days: 14,
+      verify_email_url: url`/verifyEmail/${emailCode}`,
+    }),
+  ])
+
+  return true
+})

--- a/app/core/components/Banner.tsx
+++ b/app/core/components/Banner.tsx
@@ -1,0 +1,20 @@
+import { Link, LinkProps } from "@blitzjs/core"
+
+type BannerProps = {
+  message?: string
+  action?: string
+  url?: LinkProps
+}
+
+const Banner = ({ message, action, url }: BannerProps) => {
+  return (
+    <div className="absolute top-0 w-screen bg-yellow-400 inset-x-0 pb-2 sm:pb-5 z-100">
+      <p>{message}</p>
+      <Link href={url}>
+        <a>{action}</a>
+      </Link>
+    </div>
+  )
+}
+
+export default Banner

--- a/app/core/components/Banner.tsx
+++ b/app/core/components/Banner.tsx
@@ -1,18 +1,33 @@
-import { Link, LinkProps } from "@blitzjs/core"
+import { useMutation } from "next/data-client"
+import { Formik, Form } from "formik"
 
-type BannerProps = {
-  message?: string
-  action?: string
-  url?: LinkProps
-}
+import resendVerification from "../../auth/mutations/resendVerification"
 
-const Banner = ({ message, action, url }: BannerProps) => {
+const Banner = ({ message }) => {
+  const [resendVerificationMutation, { isSuccess }] = useMutation(resendVerification)
   return (
-    <div className="absolute top-0 w-screen bg-yellow-400 inset-x-0 pb-2 sm:pb-5 z-100">
-      <p>{message}</p>
-      <Link href={url}>
-        <a>{action}</a>
-      </Link>
+    <div className="absolute flex bottom-0 w-screen bg-yellow-400 inset-x-0 p-2 sm:p-5 z-100">
+      <p className="w-11/12">{message}</p>
+      {isSuccess ? (
+        <p>Email sent!</p>
+      ) : (
+        <Formik
+          initialValues={{}}
+          onSubmit={async () => {
+            try {
+              await resendVerificationMutation()
+            } catch (error) {
+              alert("Error saving product")
+            }
+          }}
+        >
+          <Form>
+            <button className="bg-indigo-300 p-1 rounded" type="submit">
+              Send verification
+            </button>
+          </Form>
+        </Formik>
+      )}
     </div>
   )
 }

--- a/app/pages/dashboard.tsx
+++ b/app/pages/dashboard.tsx
@@ -5,9 +5,19 @@ import moment from "moment"
 import Navbar from "../core/components/navbarApp"
 import db from "db"
 import updateInvitation from "../authorship/mutations/updateInvitation"
+import Banner from "../core/components/Banner"
 
 export const getServerSideProps = async ({ req, res }) => {
   const session = await getSession(req, res)
+  const user = await db.user.findFirst({
+    where: {
+      id: session.$publicData.userId!,
+    },
+    select: {
+      emailIsVerified: true,
+    },
+  })
+
   const draftModules = await db.module.findMany({
     where: {
       published: false,
@@ -72,14 +82,23 @@ export const getServerSideProps = async ({ req, res }) => {
     ],
   })
 
-  return { props: { draftModules, invitedModules, modules, workspaces } }
+  return { props: { user, draftModules, invitedModules, modules, workspaces } }
 }
 
-const Dashboard = ({ draftModules, invitedModules, modules, workspaces }) => {
+const Dashboard = ({ user, draftModules, invitedModules, modules, workspaces }) => {
   const [updateInvitationMutation, { isSuccess: invitationUpdated }] = useMutation(updateInvitation)
 
   return (
     <>
+      {!user.emailIsVerified ? (
+        <Banner
+          message="You can only start publishing once your email is verified. Please check your inbox."
+          action="Resend verification"
+          url="api/routes/verifiy"
+        />
+      ) : (
+        ""
+      )}
       <Navbar />
       <main className="max-w-4xl mx-auto">
         <div>

--- a/app/pages/dashboard.tsx
+++ b/app/pages/dashboard.tsx
@@ -91,11 +91,7 @@ const Dashboard = ({ user, draftModules, invitedModules, modules, workspaces }) 
   return (
     <>
       {!user.emailIsVerified ? (
-        <Banner
-          message="You can only start publishing once your email is verified. Please check your inbox."
-          action="Resend verification"
-          url="api/routes/verifiy"
-        />
+        <Banner message="You can only start publishing once your email is verified. Please check your inbox." />
       ) : (
         ""
       )}


### PR DESCRIPTION
This PR adds a rudimentary design for the functionality that when a user's email is *not* verified, there is a banner that says so in the dashboard. 

![Screenshot 2021-10-05 at 12 25 52](https://user-images.githubusercontent.com/2946344/136006044-5917242e-52ef-4af2-8d07-6fbf5b3db947.png)

Users can also send themselves a new verification email on the spot.

We may want to add this banner elsewhere too but I wasn't sure just yet and kept it local. Considerations for this are also performance - this implementation queries the server for info. Some upgrades may prove helpful by putting it into the `privateData` (as now in #33).

