### PR TITLE
Add option to delete draft module

### DIFF
--- a/app/core/modals/DeleteModuleModal.tsx
+++ b/app/core/modals/DeleteModuleModal.tsx
@@ -1,0 +1,88 @@
+import { useMutation, useRouter } from "blitz"
+import { Fragment, useState } from "react"
+import { Dialog, Transition } from "@headlessui/react"
+import deleteModule from "app/modules/mutations/deleteModule"
+
+export default function DeleteModule({ module }) {
+  let [isOpen, setIsOpen] = useState(false)
+  const [deleteModuleMutation] = useMutation(deleteModule)
+  const router = useRouter()
+
+  function closeModal() {
+    setIsOpen(false)
+  }
+
+  function openModal() {
+    setIsOpen(true)
+  }
+
+  return (
+    <>
+      <button className="px-4 py-2 bg-red-500 text-white hover:bg-red-300" onClick={openModal}>
+        Delete
+      </button>
+      <Transition appear show={isOpen} as={Fragment}>
+        <Dialog as="div" className="fixed inset-0 z-10 overflow-y-auto" onClose={closeModal}>
+          <div className="min-h-screen px-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0"
+              enterTo="opacity-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <Dialog.Overlay className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+            </Transition.Child>
+
+            {/* This element is to trick the browser into centering the modal contents. */}
+            <span className="inline-block h-screen align-middle" aria-hidden="true">
+              &#8203;
+            </span>
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <div className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
+                <Dialog.Title as="h3" className="text-lg font-medium leading-6 text-gray-900">
+                  Confirm
+                </Dialog.Title>
+                <div className="mt-2">
+                  <p className="text-sm text-gray-500">
+                    The module will be deleted once you verify. No co-author approval is needed to
+                    do this.
+                  </p>
+                </div>
+                <div className="mt-4">
+                  <button
+                    type="button"
+                    className="inline-flex justify-center px-4 py-2 text-sm font-medium text-blue-900 bg-blue-100 border border-transparent rounded-md hover:bg-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 mr-4"
+                    onClick={async () => {
+                      await deleteModuleMutation({ id: module.id })
+                      router.push("/dashboard")
+                    }}
+                  >
+                    Delete
+                  </button>
+                  <button
+                    type="button"
+                    className="inline-flex justify-center px-4 py-2 text-sm font-medium text-red-900 bg-red-100 border border-transparent rounded-md hover:bg-red-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500"
+                    onClick={closeModal}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            </Transition.Child>
+          </div>
+        </Dialog>
+      </Transition>
+    </>
+  )
+}

--- a/app/core/modals/ReadyToPublishModal.tsx
+++ b/app/core/modals/ReadyToPublishModal.tsx
@@ -1,0 +1,101 @@
+import publishModule from "app/modules/mutations/publishModule"
+import { useMutation, useRouter } from "blitz"
+import { Fragment, useState } from "react"
+import { Dialog, Transition } from "@headlessui/react"
+
+export default function ReadyToPublish({ module }) {
+  let [isOpen, setIsOpen] = useState(false)
+  const [publishMutation] = useMutation(publishModule)
+  const router = useRouter()
+
+  function closeModal() {
+    setIsOpen(false)
+  }
+
+  function openModal() {
+    setIsOpen(true)
+  }
+
+  return (
+    <>
+      <button
+        className="px-4 py-2 bg-indigo-500 text-white hover:bg-indigo-300"
+        onClick={openModal}
+        // async () => {
+        //   await publishMutation({ id: module.id })
+        //   router.reload()
+        // }}
+      >
+        Publish
+      </button>
+      <Transition appear show={isOpen} as={Fragment}>
+        <Dialog as="div" className="fixed inset-0 z-10 overflow-y-auto" onClose={closeModal}>
+          <div className="min-h-screen px-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0"
+              enterTo="opacity-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <Dialog.Overlay className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+            </Transition.Child>
+
+            {/* This element is to trick the browser into centering the modal contents. */}
+            <span className="inline-block h-screen align-middle" aria-hidden="true">
+              &#8203;
+            </span>
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <div className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
+                <Dialog.Title as="h3" className="text-lg font-medium leading-6 text-gray-900">
+                  Confirm
+                </Dialog.Title>
+                <div className="mt-2">
+                  <p className="text-sm text-gray-500">
+                    When all authors approve the current version, the research module will be
+                    automatically published.
+                  </p>
+                  <p className="text-sm text-gray-500">
+                    If any of your co-authors makes a change, you will have to re-approve for
+                    publication.
+                  </p>
+                </div>
+
+                <div className="mt-4">
+                  <button
+                    type="button"
+                    className="inline-flex justify-center px-4 py-2 text-sm font-medium text-blue-900 bg-blue-100 border border-transparent rounded-md hover:bg-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 mr-4"
+                    onClick={async () => {
+                      await publishMutation({ id: module.id })
+                      router.reload()
+                      // closeModal()
+                    }}
+                  >
+                    Approve for publishing
+                  </button>
+                  <button
+                    type="button"
+                    className="inline-flex justify-center px-4 py-2 text-sm font-medium text-red-900 bg-red-100 border border-transparent rounded-md hover:bg-red-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500"
+                    onClick={closeModal}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            </Transition.Child>
+          </div>
+        </Dialog>
+      </Transition>
+    </>
+  )
+}

--- a/app/modules/mutations/deleteModule.ts
+++ b/app/modules/mutations/deleteModule.ts
@@ -1,0 +1,13 @@
+import { resolver } from "blitz"
+import db from "db"
+
+export default resolver.pipe(resolver.authorize(), async ({ id }) => {
+  await db.authorship.deleteMany({ where: { moduleId: id } })
+  await db.module.delete({
+    where: {
+      id,
+    },
+  })
+
+  return true
+})

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -5,6 +5,8 @@ import Layout from "../../core/layouts/Layout"
 import db from "db"
 import publishModule from "app/modules/mutations/publishModule"
 import NavbarApp from "../../core/components/navbarApp"
+import ReadyToPublishModal from "../../core/modals/ReadyToPublishModal"
+import DeleteModuleModal from "../../core/modals/DeleteModuleModal"
 
 export const getServerSideProps = async ({ params, req, res }) => {
   const session = await getSession(req, res)
@@ -44,14 +46,6 @@ const ModulePage = ({ module, isAuthor }) => {
   const router = useRouter()
   let [isOpen, setIsOpen] = useState(false)
 
-  function closeModal() {
-    setIsOpen(false)
-  }
-
-  function openModal() {
-    setIsOpen(true)
-  }
-
   return (
     <Layout title={`R= ${module.title}`}>
       <NavbarApp />
@@ -61,84 +55,8 @@ const ModulePage = ({ module, isAuthor }) => {
       </div>
       {isAuthor && !module.published ? (
         <>
-          <button
-            className="px-4 py-2 bg-indigo-500 text-white hover:bg-indigo-300"
-            onClick={openModal}
-            // async () => {
-            //   await publishMutation({ id: module.id })
-            //   router.reload()
-            // }}
-          >
-            Publish
-          </button>
-          <Transition appear show={isOpen} as={Fragment}>
-            <Dialog as="div" className="fixed inset-0 z-10 overflow-y-auto" onClose={closeModal}>
-              <div className="min-h-screen px-4 text-center">
-                <Transition.Child
-                  as={Fragment}
-                  enter="ease-out duration-300"
-                  enterFrom="opacity-0"
-                  enterTo="opacity-100"
-                  leave="ease-in duration-200"
-                  leaveFrom="opacity-100"
-                  leaveTo="opacity-0"
-                >
-                  <Dialog.Overlay className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
-                </Transition.Child>
-
-                {/* This element is to trick the browser into centering the modal contents. */}
-                <span className="inline-block h-screen align-middle" aria-hidden="true">
-                  &#8203;
-                </span>
-                <Transition.Child
-                  as={Fragment}
-                  enter="ease-out duration-300"
-                  enterFrom="opacity-0 scale-95"
-                  enterTo="opacity-100 scale-100"
-                  leave="ease-in duration-200"
-                  leaveFrom="opacity-100 scale-100"
-                  leaveTo="opacity-0 scale-95"
-                >
-                  <div className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
-                    <Dialog.Title as="h3" className="text-lg font-medium leading-6 text-gray-900">
-                      Confirm
-                    </Dialog.Title>
-                    <div className="mt-2">
-                      <p className="text-sm text-gray-500">
-                        When all authors approve the current version, the research module will be
-                        automatically published.
-                      </p>
-                      <p className="text-sm text-gray-500">
-                        If any of your co-authors makes a change, you will have to re-approve for
-                        publication.
-                      </p>
-                    </div>
-
-                    <div className="mt-4">
-                      <button
-                        type="button"
-                        className="inline-flex justify-center px-4 py-2 text-sm font-medium text-blue-900 bg-blue-100 border border-transparent rounded-md hover:bg-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 mr-4"
-                        onClick={async () => {
-                          await publishMutation({ id: module.id })
-                          router.reload()
-                          // closeModal()
-                        }}
-                      >
-                        Approve for publishing
-                      </button>
-                      <button
-                        type="button"
-                        className="inline-flex justify-center px-4 py-2 text-sm font-medium text-red-900 bg-red-100 border border-transparent rounded-md hover:bg-red-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500"
-                        onClick={closeModal}
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  </div>
-                </Transition.Child>
-              </div>
-            </Dialog>
-          </Transition>
+          <ReadyToPublishModal module={module} />
+          <DeleteModuleModal module={module} />
         </>
       ) : (
         ""


### PR DESCRIPTION
This PR adds a delete functionality to draft modules. This removes all authorships and ultimately the module itself.

![Screenshot 2021-10-06 at 16 27 20](https://user-images.githubusercontent.com/2946344/136223161-9d38caec-12cd-4b7f-8cd5-24b37ef8a14e.png)

Afterwards it goes back to the dashboard. Note that not all authors need to approve the deletion at this point.