### PR TITLE
Refactor unpublished and published module routes

### DIFF
--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -1,0 +1,111 @@
+import { useQuery } from "blitz"
+
+import ReadyToPublishModal from "../../core/modals/ReadyToPublishModal"
+import DeleteModuleModal from "../../core/modals/DeleteModuleModal"
+import useCurrentModule from "../queries/useCurrentModule"
+import { useEffect } from "react"
+
+const ModuleEdit = ({ user, module, isAuthor }) => {
+  const [moduleEdit, { refetch }] = useQuery(useCurrentModule, { suffix: module.suffix })
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      refetch()
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="flex justify-center items-center">
+        <h1 className="text-8xl font-black">{moduleEdit!.title!}</h1>
+      </div>
+      <div>
+        <h2 className="text-4xl font-black">Abstract</h2>
+        <p>{module.description}</p>
+      </div>
+      <div>
+        <p>{module.updatedAt.toString()}</p>
+      </div>
+      <div className="flex flex-col">
+        <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+          <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+            <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Name
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Status
+                    </th>
+                    <th scope="col" className="relative px-6 py-3">
+                      <span className="sr-only">Edit</span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {module.authors.map((author) => (
+                    <tr key={author.workspace.orcid}>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="flex items-center">
+                          {author.workspace.avatar ? (
+                            <div className="flex-shrink-0 h-10 w-10">
+                              <img
+                                className="h-10 w-10 rounded-full"
+                                src={author.workspace.avatar}
+                                alt={`Avatar of ${author.workspace.name}`}
+                              />
+                            </div>
+                          ) : (
+                            <div className="flex-shrink-0 h-10 w-10">
+                              <img
+                                className="h-10 w-10 rounded-full"
+                                src={`https://eu.ui-avatars.com/api/?rounded=true&background=random&name=${author.workspace.handle}`}
+                                alt={`Avatar of ${author.workspace.name}`}
+                              />
+                            </div>
+                          )}
+                          <div className="ml-4">
+                            <div className="text-sm font-medium text-gray-900">
+                              {author.workspace.name}
+                            </div>
+                            <div className="text-sm text-gray-500">@{author.workspace.handle}</div>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                          {author.readyToPublish.toString()}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <ReadyToPublishModal module={module} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>{JSON.stringify(module)}</div>
+      {isAuthor && !module.published && user.emailIsVerified ? (
+        <ReadyToPublishModal module={module} />
+      ) : (
+        ""
+      )}
+      {isAuthor && !module.published ? <DeleteModuleModal module={module} /> : ""}
+    </div>
+  )
+}
+
+export default ModuleEdit

--- a/app/modules/queries/useCurrentModule.ts
+++ b/app/modules/queries/useCurrentModule.ts
@@ -1,0 +1,9 @@
+import db from "db"
+
+export default async function getCurrentWorkspace({ suffix }) {
+  const module = await db.module.findFirst({
+    where: { suffix },
+  })
+
+  return module
+}

--- a/app/pages/dashboard.tsx
+++ b/app/pages/dashboard.tsx
@@ -117,7 +117,7 @@ const Dashboard = ({ user, draftModules, invitedModules, modules, workspaces }) 
               return (
                 <p key={draft.suffix}>
                   Last edited: {moment(draft.updatedAt).fromNow()}
-                  <Link href={Routes.ModulePage({ suffix: draft.suffix })}>
+                  <Link href={Routes.ModuleEditPage({ suffix: draft.suffix })}>
                     <a>
                       10.53962/{draft.suffix} {draft.title}
                     </a>

--- a/app/pages/dashboard.tsx
+++ b/app/pages/dashboard.tsx
@@ -164,7 +164,7 @@ const Dashboard = ({ user, draftModules, invitedModules, modules, workspaces }) 
                   <span>Thanks for responding to this invitation</span>
                 ) : (
                   <>
-                    <Link href={Routes.ModulePage({ suffix: invitation.suffix })}>
+                    <Link href={Routes.ModuleEditPage({ suffix: invitation.suffix })}>
                       <a>
                         {moment(invitation.createdAt).fromNow()} 10.53962/{invitation.suffix}{" "}
                         {invitation.title}

--- a/app/pages/edit/[suffix].tsx
+++ b/app/pages/edit/[suffix].tsx
@@ -11,8 +11,6 @@ import DeleteModuleModal from "../../core/modals/DeleteModuleModal"
 export const getServerSideProps = async ({ params, req, res }) => {
   const session = await getSession(req, res)
 
-  console.log(params)
-
   const suffix = params!.suffix
   const module = await db.module.findFirst({
     where: { suffix },

--- a/app/pages/edit/[suffix].tsx
+++ b/app/pages/edit/[suffix].tsx
@@ -1,5 +1,5 @@
 import { getSession, useMutation, useRouter } from "blitz"
-import { useState } from "react"
+import { useState, Suspense } from "react"
 import Layout from "../../core/layouts/Layout"
 import db from "db"
 import publishModule from "app/modules/mutations/publishModule"
@@ -7,19 +7,8 @@ import NavbarApp from "../../core/components/navbarApp"
 import ReadyToPublishModal from "../../core/modals/ReadyToPublishModal"
 import DeleteModuleModal from "../../core/modals/DeleteModuleModal"
 import Banner from "../../core/components/Banner"
-
-const people = [
-  {
-    name: "Jane Cooper",
-    title: "Regional Paradigm Technician",
-    department: "Optimization",
-    role: "Admin",
-    email: "jane.cooper@example.com",
-    image:
-      "https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60",
-  },
-  // More people...
-]
+import useCurrentModule from "../../modules/queries/useCurrentModule"
+import ModuleEdit from "../../modules/components/ModuleEdit"
 
 export const getServerSideProps = async ({ params, req, res }, ctx) => {
   const session = await getSession(req, res)
@@ -74,97 +63,9 @@ const ModuleEditPage = ({ user, module, isAuthor }) => {
         ""
       )}
       <NavbarApp />
-      <div className="max-w-4xl mx-auto">
-        <div className="flex justify-center items-center">
-          <h1 className="text-8xl font-black">{module.title}</h1>
-        </div>
-        <div>
-          <h2 className="text-4xl font-black">Abstract</h2>
-          <p>{module.description}</p>
-        </div>
-        <div>
-          <p>{module.updatedAt.toString()}</p>
-        </div>
-        <div className="flex flex-col">
-          <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-            <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-              <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
-                <table className="min-w-full divide-y divide-gray-200">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th
-                        scope="col"
-                        className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                      >
-                        Name
-                      </th>
-                      <th
-                        scope="col"
-                        className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                      >
-                        Status
-                      </th>
-                      <th scope="col" className="relative px-6 py-3">
-                        <span className="sr-only">Edit</span>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="bg-white divide-y divide-gray-200">
-                    {module.authors.map((author) => (
-                      <tr key={author.workspace.orcid}>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <div className="flex items-center">
-                            {author.workspace.avatar ? (
-                              <div className="flex-shrink-0 h-10 w-10">
-                                <img
-                                  className="h-10 w-10 rounded-full"
-                                  src={author.workspace.avatar}
-                                  alt={`Avatar of ${author.workspace.name}`}
-                                />
-                              </div>
-                            ) : (
-                              <div className="flex-shrink-0 h-10 w-10">
-                                <img
-                                  className="h-10 w-10 rounded-full"
-                                  src={`https://eu.ui-avatars.com/api/?rounded=true&background=random&name=${author.workspace.handle}`}
-                                  alt={`Avatar of ${author.workspace.name}`}
-                                />
-                              </div>
-                            )}
-                            <div className="ml-4">
-                              <div className="text-sm font-medium text-gray-900">
-                                {author.workspace.name}
-                              </div>
-                              <div className="text-sm text-gray-500">
-                                @{author.workspace.handle}
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                            {author.readyToPublish.toString()}
-                          </span>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                          <ReadyToPublishModal module={module} />
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div>{JSON.stringify(module)}</div>
-        {isAuthor && !module.published && user.emailIsVerified ? (
-          <ReadyToPublishModal module={module} />
-        ) : (
-          ""
-        )}
-        {isAuthor && !module.published ? <DeleteModuleModal module={module} /> : ""}
-      </div>
+      <Suspense fallback="Loading...">
+        <ModuleEdit user={user} module={module} isAuthor={isAuthor} />
+      </Suspense>
     </Layout>
   )
 }

--- a/app/pages/edit/[suffix].tsx
+++ b/app/pages/edit/[suffix].tsx
@@ -1,21 +1,44 @@
 import { getSession, useMutation, useRouter } from "blitz"
-import { Dialog, Transition } from "@headlessui/react"
-import { Fragment, useState } from "react"
+import { useState } from "react"
 import Layout from "../../core/layouts/Layout"
 import db from "db"
 import publishModule from "app/modules/mutations/publishModule"
 import NavbarApp from "../../core/components/navbarApp"
 import ReadyToPublishModal from "../../core/modals/ReadyToPublishModal"
 import DeleteModuleModal from "../../core/modals/DeleteModuleModal"
+import Banner from "../../core/components/Banner"
 
-export const getServerSideProps = async ({ params, req, res }) => {
+const people = [
+  {
+    name: "Jane Cooper",
+    title: "Regional Paradigm Technician",
+    department: "Optimization",
+    role: "Admin",
+    email: "jane.cooper@example.com",
+    image:
+      "https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60",
+  },
+  // More people...
+]
+
+export const getServerSideProps = async ({ params, req, res }, ctx) => {
   const session = await getSession(req, res)
 
   const suffix = params!.suffix
   const module = await db.module.findFirst({
     where: { suffix },
     include: {
-      authors: true,
+      authors: {
+        include: {
+          workspace: true,
+        },
+      },
+    },
+  })
+
+  const user = await db.user.findFirst({
+    where: {
+      id: session.$publicData.userId == null ? 0 : session.$publicData.userId,
     },
   })
 
@@ -37,31 +60,111 @@ export const getServerSideProps = async ({ params, req, res }) => {
       module,
       isAuthor: module.authors.filter((e) => e.workspaceId === session.$publicData.workspaceId)
         .length,
+      user,
     },
   }
 }
 
-const ModuleEditPage = ({ module, isAuthor }) => {
-  const [publishMutation] = useMutation(publishModule)
-  const router = useRouter()
-  let [isOpen, setIsOpen] = useState(false)
-
+const ModuleEditPage = ({ user, module, isAuthor }) => {
   return (
     <Layout title={`R= ${module.title}`}>
-      <NavbarApp />
-      <div className="flex justify-center items-center">
-        <h1>{module.title}</h1>
-        <p>{module.description}</p>
-      </div>
-      {isAuthor && !module.published ? (
-        <>
-          <ReadyToPublishModal module={module} />
-          <DeleteModuleModal module={module} />
-        </>
+      {!user.emailIsVerified ? (
+        <Banner message="You can only start publishing once your email is verified. Please check your inbox." />
       ) : (
         ""
       )}
-      <div>{JSON.stringify(module)}</div>
+      <NavbarApp />
+      <div className="max-w-4xl mx-auto">
+        <div className="flex justify-center items-center">
+          <h1 className="text-8xl font-black">{module.title}</h1>
+        </div>
+        <div>
+          <h2 className="text-4xl font-black">Abstract</h2>
+          <p>{module.description}</p>
+        </div>
+        <div>
+          <p>{module.updatedAt.toString()}</p>
+        </div>
+        <div className="flex flex-col">
+          <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+              <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
+                        Name
+                      </th>
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
+                        Status
+                      </th>
+                      <th scope="col" className="relative px-6 py-3">
+                        <span className="sr-only">Edit</span>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {module.authors.map((author) => (
+                      <tr key={author.workspace.orcid}>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <div className="flex items-center">
+                            {author.workspace.avatar ? (
+                              <div className="flex-shrink-0 h-10 w-10">
+                                <img
+                                  className="h-10 w-10 rounded-full"
+                                  src={author.workspace.avatar}
+                                  alt={`Avatar of ${author.workspace.name}`}
+                                />
+                              </div>
+                            ) : (
+                              <div className="flex-shrink-0 h-10 w-10">
+                                <img
+                                  className="h-10 w-10 rounded-full"
+                                  src={`https://eu.ui-avatars.com/api/?rounded=true&background=random&name=${author.workspace.handle}`}
+                                  alt={`Avatar of ${author.workspace.name}`}
+                                />
+                              </div>
+                            )}
+                            <div className="ml-4">
+                              <div className="text-sm font-medium text-gray-900">
+                                {author.workspace.name}
+                              </div>
+                              <div className="text-sm text-gray-500">
+                                @{author.workspace.handle}
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                            {author.readyToPublish.toString()}
+                          </span>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                          <ReadyToPublishModal module={module} />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>{JSON.stringify(module)}</div>
+        {isAuthor && !module.published && user.emailIsVerified ? (
+          <ReadyToPublishModal module={module} />
+        ) : (
+          ""
+        )}
+        {isAuthor && !module.published ? <DeleteModuleModal module={module} /> : ""}
+      </div>
     </Layout>
   )
 }

--- a/app/pages/edit/[suffix].tsx
+++ b/app/pages/edit/[suffix].tsx
@@ -1,0 +1,71 @@
+import { getSession, useMutation, useRouter } from "blitz"
+import { Dialog, Transition } from "@headlessui/react"
+import { Fragment, useState } from "react"
+import Layout from "../../core/layouts/Layout"
+import db from "db"
+import publishModule from "app/modules/mutations/publishModule"
+import NavbarApp from "../../core/components/navbarApp"
+import ReadyToPublishModal from "../../core/modals/ReadyToPublishModal"
+import DeleteModuleModal from "../../core/modals/DeleteModuleModal"
+
+export const getServerSideProps = async ({ params, req, res }) => {
+  const session = await getSession(req, res)
+
+  console.log(params)
+
+  const suffix = params!.suffix
+  const module = await db.module.findFirst({
+    where: { suffix },
+    include: {
+      authors: true,
+    },
+  })
+
+  // Throw 404 if
+  // 1. Module does not exist
+  // 2. Module exists but is unpublished and not authored by current workspace
+  if (
+    !module ||
+    (module.published === false &&
+      !(module.authors.filter((e) => e.workspaceId === session.$publicData.workspaceId).length > 0))
+  ) {
+    return {
+      notFound: true,
+    }
+  }
+
+  return {
+    props: {
+      module,
+      isAuthor: module.authors.filter((e) => e.workspaceId === session.$publicData.workspaceId)
+        .length,
+    },
+  }
+}
+
+const ModuleEditPage = ({ module, isAuthor }) => {
+  const [publishMutation] = useMutation(publishModule)
+  const router = useRouter()
+  let [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <Layout title={`R= ${module.title}`}>
+      <NavbarApp />
+      <div className="flex justify-center items-center">
+        <h1>{module.title}</h1>
+        <p>{module.description}</p>
+      </div>
+      {isAuthor && !module.published ? (
+        <>
+          <ReadyToPublishModal module={module} />
+          <DeleteModuleModal module={module} />
+        </>
+      ) : (
+        ""
+      )}
+      <div>{JSON.stringify(module)}</div>
+    </Layout>
+  )
+}
+
+export default ModuleEditPage

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -1,51 +1,45 @@
-import { getSession, useMutation, useRouter } from "blitz"
-import { Dialog, Transition } from "@headlessui/react"
-import { Fragment, useState } from "react"
 import Layout from "../../core/layouts/Layout"
 import db from "db"
-import publishModule from "app/modules/mutations/publishModule"
 import NavbarApp from "../../core/components/navbarApp"
-import ReadyToPublishModal from "../../core/modals/ReadyToPublishModal"
-import DeleteModuleModal from "../../core/modals/DeleteModuleModal"
 
-export const getServerSideProps = async ({ params, req, res }) => {
-  const session = await getSession(req, res)
-
-  const suffix = params!.suffix
-  const module = await db.module.findFirst({
-    where: { suffix },
-    include: {
-      authors: true,
+export async function getStaticPaths() {
+  const modules = await db.module.findMany({
+    where: {
+      published: {
+        equals: true,
+      },
     },
   })
-
-  // Throw 404 if
-  // 1. Module does not exist
-  // 2. Module exists but is unpublished and not authored by current workspace
-  if (
-    !module ||
-    (module.published === false &&
-      !(module.authors.filter((e) => e.workspaceId === session.$publicData.workspaceId).length > 0))
-  ) {
+  const pathObject = modules.map((module) => {
     return {
-      notFound: true,
+      params: {
+        suffix: module.suffix,
+      },
     }
+  })
+  console.log(pathObject)
+
+  return {
+    paths: pathObject,
+    fallback: false,
   }
+}
+
+export async function getStaticProps(context) {
+  const module = await db.module.findFirst({
+    where: {
+      suffix: context.params.suffix,
+    },
+  })
 
   return {
     props: {
       module,
-      isAuthor: module.authors.filter((e) => e.workspaceId === session.$publicData.workspaceId)
-        .length,
-    },
+    }, // will be passed to the page component as props
   }
 }
 
-const ModulePage = ({ module, isAuthor }) => {
-  const [publishMutation] = useMutation(publishModule)
-  const router = useRouter()
-  let [isOpen, setIsOpen] = useState(false)
-
+const ModulePage = ({ module }) => {
   return (
     <Layout title={`R= ${module.title}`}>
       <NavbarApp />
@@ -53,14 +47,6 @@ const ModulePage = ({ module, isAuthor }) => {
         <h1>{module.title}</h1>
         <p>{module.description}</p>
       </div>
-      {isAuthor && !module.published ? (
-        <>
-          <ReadyToPublishModal module={module} />
-          <DeleteModuleModal module={module} />
-        </>
-      ) : (
-        ""
-      )}
       <div>{JSON.stringify(module)}</div>
     </Layout>
   )


### PR DESCRIPTION
This PR refactors the `/modules/[suffix]` route for all work on modules into one for serving static, published (`/modules/[suffix]`) and one for editing unpublished modules (`/edit/[suffix]`).

This means that all pages for the published ones will be pre-built and not require queries to the server upon each load. The unpublished and editable modules will still require those queries. 

This refactor helps make the pages more performant and increases SEO as a result too. Plus it reduces query load on the server. This does not have any drastic changes above the hood.