### PR TITLE
Add generic avatar

### DIFF
--- a/app/auth/mutations/signup.ts
+++ b/app/auth/mutations/signup.ts
@@ -12,6 +12,7 @@ const index = client.initIndex("dev_workspaces")
 
 export default resolver.pipe(resolver.zod(Signup), async ({ email, password, handle }, ctx) => {
   const hashedPassword = await SecurePassword.hash(password.trim())
+  const hexColor = Math.floor(Math.random() * 16777215).toString(16)
   const user = await db.user.create({
     data: {
       email: email.toLowerCase().trim(),
@@ -23,6 +24,7 @@ export default resolver.pipe(resolver.zod(Signup), async ({ email, password, han
           workspace: {
             create: {
               handle,
+              avatar: `https://eu.ui-avatars.com/api/?rounded=true&background=${hexColor}&name=${handle}`,
             },
           },
         },


### PR DESCRIPTION
This PR adds a generic avatar for each signup. This helps prevent empty avatars 😊 

This is all based on https://eu.ui-avatars.com/ - we hardcode a hexcolor into the link so that they remain recognizable.

![](https://eu.ui-avatars.com/api/?background=0D8ABC&color=fff&name=PR&rounded=true)

This way we don't have to add code to recognize when a workspace has an avatar and then generate the relevant link. Saves a bunch of logic.